### PR TITLE
Re-implemented two-parameter photometric calibration

### DIFF
--- a/pyDANDIA/calibrate_photometry.py
+++ b/pyDANDIA/calibrate_photometry.py
@@ -893,8 +893,11 @@ def phot_weighted_mean(data,sigma):
 def phot_func(p,mags):
     """Photometric transform function"""
     # Expected function is of the form p[0]*mags + p[1]
-    return np.polyval(p,mags)
-
+    if len(p) == 2:
+        return np.polyval(p,mags)
+    else:
+        raise IndexError('Photometric transform called with an unexpected number of terms')
+        
 def errfunc(p,x,y):
     """Function to calculate the residuals on the photometric transform"""
 

--- a/pyDANDIA/calibrate_photometry.py
+++ b/pyDANDIA/calibrate_photometry.py
@@ -892,13 +892,8 @@ def phot_weighted_mean(data,sigma):
 
 def phot_func(p,mags):
     """Photometric transform function"""
-
-    # Switch for a fixed single zeropoint
-    fit_zp_only = False
-    if fit_zp_only:
-        p[0] = 1.0
-
-    return p[0]*mags + p[1]
+    # Expected function is of the form p[0]*mags + p[1]
+    return np.polyval(p,mags)
 
 def errfunc(p,x,y):
     """Function to calculate the residuals on the photometric transform"""

--- a/pyDANDIA/calibrate_photometry.py
+++ b/pyDANDIA/calibrate_photometry.py
@@ -893,8 +893,11 @@ def phot_weighted_mean(data,sigma):
 def phot_func(p,mags):
     """Photometric transform function"""
 
-    # Single zeropoint
-    p[0] = 1.0
+    # Switch for a fixed single zeropoint
+    fit_zp_only = False
+    if fit_zp_only:
+        p[0] = 1.0
+
     return p[0]*mags + p[1]
 
 def errfunc(p,x,y):
@@ -914,7 +917,7 @@ def calc_transform(pinit, x, y):
     odr_obj = ODR(dataset, linear_model, beta0=pinit)
     results = odr_obj.run()
 
-    pfit = [results.beta[0], results.beta[1]]
+    pfit = np.array([results.beta[0], results.beta[1]])
     covar_fit = results.cov_beta*results.res_var
 
     return pfit, covar_fit

--- a/pyDANDIA/tests/test_calibrate_photometry.py
+++ b/pyDANDIA/tests/test_calibrate_photometry.py
@@ -24,22 +24,28 @@ TEST_DIR = path.join(cwd,'data','proc',
                         'ROME-FIELD-0002_lsc-doma-1m0-05-fl15_ip')
 
 def test_calc_transform():
-    """Function to test the photometric transform function"""
+    """Function to test the photometric transform function
 
-    a = [ 16.0, 0.15 ]
-    x = np.linspace(1.0,100.0,100)
-    y = a[0] + (x * a[1]) + np.random.normal(0.0, scale=0.5)
+    Expected calibration function is of the form:
+    mag_cal = p[0]*mag + p[1]
+    """
+
+    a = [ 0.15, 16.0 ]
+    uncertainty = [0.01, 0.5]
+    x = np.linspace(10.0,20.0,10)
+    y = (a[0]*x) + a[1] + np.random.normal(0.0, scale=0.5)
 
     p = [ -1.0, -10.0 ]
 
     (fit,covar_fit) = calibrate_photometry.calc_transform(p, x, y)
 
-    assert fit.all() == np.array(a).all()
+    for i in range(0,1,1):
+        np.testing.assert_almost_equal(fit[i],a[i],uncertainty[i])
 
     fig = plt.figure(1)
 
     xplot = np.linspace(x.min(),x.max(),10)
-    yplot = fit[0] + xplot * fit[1]
+    yplot = fit[0]*xplot + fit[1]
 
     plt.plot(x,y,'m.')
 
@@ -144,9 +150,9 @@ def test_calc_calibrated_mags():
 
 if __name__ == '__main__':
 
-    #test_calc_transform()
+    test_calc_transform()
     #test_fetch_catalog_sources_within_image()
     #test_fetch_catalog_sources_from_metadata()
     #test_parse_phot_calibration_file()
     #test_calc_transform_uncertainty()
-    test_calc_calibrated_mags()
+    #test_calc_calibrated_mags()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ pystackreg
 astroalign
 psutil
 seaborn
-pillow>=8.1.1
+pillow>=9.0.1
 boto3
 h5py

--- a/requirements_ops.txt
+++ b/requirements_ops.txt
@@ -1,8 +1,7 @@
 asn1crypto==0.24.0
 astroalign==1.0.4
 astropy==4.2.1
-astropy-healpix==0.4
-astroquery==0.3.10
+astroquery==2.4.7
 astroscrappy==1.0.8
 atomicwrites==1.3.0
 attrs==18.2.0


### PR DESCRIPTION
Since the code infrastructure for two-parameter photometric calibrations remained in place, I have added a switch in calibrate_photometry.phot_func to allow us to switch between one or two parameters.  By default, this is now switched to use a two-parameter transform.  The same function is used by stage3 and stage6, so I believe this should resolve the issue.  

Please review this implementation and verify that it matches your expectations.  